### PR TITLE
Math rendering with Katex 0.8.3 & serve files from .md base folder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,3 +42,13 @@ All changes for this release were made in the backend. Do `[sudo] npm -g update 
 - Plugin should be _much_ more performant and stable. Should be able to edit at brisk typing speed without slowdowns or crashes.
 - Updated to the latest github styles!
   - Due to github not fully open-sourcing their current syntax highlighting pipeline, syntax highlighting colors are _slightly_ different.
+
+### 0.0.9 (12-13-2017)
+Changes proposed by @twidxuga:
+
+- Implemented math rendering with Katex 0.8.3 (in instant-markdown-d). Note that a newer branch of markdown-it-katex was added as a dependency, since it works well with newer versions of Katex (master only goes up to 0.7.1).
+- It is now possible to server all files starting from the folder containing the markdown file being edited if the new option  `g:instant_markdown_serve_folder_tree = 0` is specified in a user's .vimrc/init.vim (default value is set to 0). This allows serving images, pdf files, svg files, etc. without restriction by format. 
+- Fixed issue (at least with Neovim and Linux) by which environment variables set in the vim plugin were not passed onto the instant-markdown-d server.
+- Re-factored all CSS and font files under the sames folder `imd_static` (Perhaps the Katex fonts and its CSS could be referenced from the node_modules directory in future, as an improvement)
+
+

--- a/after/ftplugin/markdown/instant-markdown.vim
+++ b/after/ftplugin/markdown/instant-markdown.vim
@@ -19,6 +19,10 @@ if !exists('g:instant_markdown_allow_external_content')
     let g:instant_markdown_allow_external_content = 1
 endif
 
+if !exists('g:instant_markdown_serve_folder_tree')
+    let g:instant_markdown_serve_folder_tree = 0
+endif
+
 " # Utility Functions
 " Simple system wrapper that ignores empty second args
 function! s:system(cmd, stdin)
@@ -66,17 +70,22 @@ function! s:refreshView()
 endfu
 
 function! s:startDaemon(initialMDLines)
-    let env = ''
     if g:instant_markdown_open_to_the_world
-        let env .= 'INSTANT_MARKDOWN_OPEN_TO_THE_WORLD=1 '
+        let $INSTANT_MARKDOWN_OPEN_TO_THE_WORLD=1
     endif
     if g:instant_markdown_allow_unsafe_content
-        let env .= 'INSTANT_MARKDOWN_ALLOW_UNSAFE_CONTENT=1 '
+        let $INSTANT_MARKDOWN_ALLOW_UNSAFE_CONTENT=1
     endif
     if !g:instant_markdown_allow_external_content
-        let env .= 'INSTANT_MARKDOWN_BLOCK_EXTERNAL=1 '
+        let $INSTANT_MARKDOWN_BLOCK_EXTERNAL=1
     endif
-
+    if g:instant_markdown_serve_folder_tree
+        let $INSTANT_MARKDOWN_SERVE_FOLDER_TREE=1
+        let l:md_file_path = expand('%:p:h')
+        call s:systemasync("cd '" . l:md_file_path . "' && " . 'instant-markdown-d', 
+                      \ a:initialMDLines)
+        return
+    endif
     call s:systemasync('instant-markdown-d', a:initialMDLines)
 endfu
 


### PR DESCRIPTION
Thanks for this awesome plugin, which I use everyday!

The code in this pull request was only tested with [Neovim](https://neovim.io/) and requires [my other pull request to the server side instant-markdown-d](https://github.com/suan/instant-markdown-d/pull/46). Math rendering with Katex is enabled by the server side, not the client side. 

**The changes to the vim plugin (client side):**

- Make it possible possible to serve all files, starting from the folder containing the markdown file being edited, if the new option  `let g:instant_markdown_serve_folder_tree = 1` is specified in `.vimrc` or `init.vim` (default value is set to 0 due to security concerns). In other words, this allows serving images, pdf files, svg files, etc. without restriction of format, using the base folder of the markdown document (the folder in which the document is in), as the base of the served folder tree. 

- Fixed issue (at least with [Neovim](https://neovim.io/) on Linux) by which environment variables set in the vim plugin were NOT passed onto the instant-markdown-d server (this was not tested in vim, only Neovim).