### PR TITLE
Place autoscroll marker on new line after previous empty line that is…

### DIFF
--- a/ftplugin/markdown/instant-markdown.vim
+++ b/ftplugin/markdown/instant-markdown.vim
@@ -157,17 +157,20 @@ function! s:bufGetLines(bufnr)
 
   if g:instant_markdown_autoscroll
     " inject row marker
-    let row_num = max([0, line(".") - 5])
-    if len(lines) < 3
-      return lines
-    endif
 
-    "From lines[row_num] find the previous empty line that is followed by a non-empty line, or the first line.
-    while ( row_num > 0 ) && !(lines[row_num] =~ '^\s*$' && !(lines[row_num + 1] =~ '^\s*$'))
-      let row_num += -1
-    endwhile
-    
-    "Insert new line with marker otherwise two paragraphs might be fused.
+    " The marker is inserted after an empty line to prevent it from interfering with
+    " mathjax/latex equations (which do not allow empty lines). The marker needs to be inserted
+    " before a non-empty line. 
+
+    " start of line followed by optional whitespace
+    " followed by one of '\r\n', '\r' or '\n' optionally followed by white
+    " space followed by non-whitespace '\S'
+    let pattern = '^\s*\(\(\r\n\|[\n\r]\).*\S\)\@='
+
+    " search backwards from cursor and don't wrap around and don't move cursor
+    let row_num = search(pattern,'bnW')
+
+    " The marker needs to be inserted on new line otherwise two paragraphs might be fused.
     call insert(lines, '<a name="#marker" id="marker"></a>', row_num)
   endif
 

--- a/ftplugin/markdown/instant-markdown.vim
+++ b/ftplugin/markdown/instant-markdown.vim
@@ -158,7 +158,17 @@ function! s:bufGetLines(bufnr)
   if g:instant_markdown_autoscroll
     " inject row marker
     let row_num = max([0, line(".") - 5])
-    let lines[row_num] = join([lines[row_num], '<a name="#marker" id="marker"></a>'], ' ')
+    if len(lines) < 3
+      return lines
+    endif
+
+    "From lines[row_num] find the previous empty line that is followed by a non-empty line, or the first line.
+    while ( row_num > 0 ) && !(lines[row_num] =~ '^\s*$' && !(lines[row_num + 1] =~ '^\s*$'))
+      let row_num += -1
+    endwhile
+    
+    "Insert new line with marker otherwise two paragraphs might be fused.
+    call insert(lines, '<a name="#marker" id="marker"></a>', row_num)
   endif
 
   return lines


### PR DESCRIPTION
… followed by a non-empty line to prevent marker from interfering with multiline latex equations. Issue #203