### PR TITLE
readme: add link to AUR package

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,9 @@ Installation
   necessary),
 - Open a markdown file in Vim and enjoy!
 
+**Arch-based distributions**
+- There is a package available on the AUR that installs the plugin:
+    - [vim-instant-markdown](https://aur.archlinux.org/packages/vim-instant-markdown)
 
 Configuration
 -------------


### PR DESCRIPTION
I'm a new maintainer of the AUR package:
- [`aur/vim-instant-markdown`](https://aur.archlinux.org/packages/vim-instant-markdown)

I thought I'd mention its existence in the README because it makes the plugin installation process quite easy.